### PR TITLE
Remove unsupported target aarch64_32

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1028,7 +1028,7 @@ fn libprovider(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.bu
             .x86, .x86_64 => &.{
                 "providers/implementations/rands/seeding/rand_cpu_x86.c",
             },
-            .aarch64, .aarch64_32 => &.{
+            .aarch64 => &.{
                 "providers/implementations/rands/seeding/rand_cpu_arm64.c",
             },
             else => &.{},


### PR DESCRIPTION
This removes the `aarch64_32` target, which latest Zig [does not support.](https://github.com/ziglang/zig/blob/242d268a06261d31161ad3a30ac0c2827ca49d99/lib/std/Target.zig#L1164)
